### PR TITLE
Update FLORIS dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,8 +34,8 @@ classifiers = [
 ]
 dependencies = [
   "numpy",
-  # "floris>=4.2.1",
-  "floris @ git+https://github.com/rafmudaf/floris.git@defaults_init#egg=floris",
+  # "floris>=4.3",
+  "floris @ git+https://github.com/nrel/floris.git@develop#egg=floris",
   "wisdem==3.18.1",
   "NLopt",
   "marmot-agents",


### PR DESCRIPTION
This pull request switches the FLORIS dependency to use the main FLORIS repository rather than my fork since a necessary feature was completed in https://github.com/NREL/floris/pull/1040. Note that this should be updated again when the next version of FLORIS is released, v4.3.