### PR TITLE
switch to floating in example

### DIFF
--- a/examples/offshore/optimization_demo.py
+++ b/examples/offshore/optimization_demo.py
@@ -197,7 +197,7 @@ model.add_subsystem(  # turbine capital costs component
 if modeling_options["offshore"]:
     model.add_subsystem(  # Orbit component
         "orbit",
-        ard.cost.wisdem_wrap.Orbit(),
+        ard.cost.wisdem_wrap.Orbit(floating=True),
     )
     model.connect(  # effective primary spacing for BOS
         "spacing_effective_primary", "orbit.plant_turbine_spacing"


### PR DESCRIPTION
The example optimization_demo.py was using the ORBIT defaults, which is a fixed-bottom case. This PR switches to floating.