### PR TITLE
Bugfix

### DIFF
--- a/.github/workflows/python-tests-system.yml
+++ b/.github/workflows/python-tests-system.yml
@@ -12,7 +12,7 @@ jobs:
   test:
     strategy:
       matrix:
-        python-version: [3.13, 3.12] # ["3.10", "3.11", "3.12", "3.13"]
+        python-version: [3.12] # ["3.10", "3.11", "3.12", "3.13"]
         os: [macos-latest, ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/python-tests-unit.yml
+++ b/.github/workflows/python-tests-unit.yml
@@ -12,7 +12,7 @@ jobs:
   test:
     strategy:
       matrix:
-        python-version: [3.13, 3.12] # ["3.10", "3.11", "3.12", "3.13"]
+        python-version: [3.12] # ["3.10", "3.11", "3.12", "3.13"]
         os: [macos-latest, ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ authors = [
 ]
 description = "A package for multidisciplinary and/or multifidelity wind farm design"
 readme= "README.md"
-requires-python = ">=3.10, <3.14"
+requires-python = ">=3.10, <3.13"
 classifiers = [
   "Development Status :: 3 - Alpha",
   "License :: OSI Approved :: Apache Software License",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ classifiers = [
   # "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
-  "numpy",
+  "numpy<2.3",
   "floris>=4.3",
   "wisdem==3.18.1",
   "NLopt",


### PR DESCRIPTION
This PR restricts numpy to less than 2.3, and python to less than 3.13 due to compatibility issues related to numba and numpy  as used in optiwindnet.