### PR TITLE
Improved OM driver interface, take II

### DIFF
--- a/ard/api/interface.py
+++ b/ard/api/interface.py
@@ -198,12 +198,12 @@ def set_up_system_recursive(
                 Driver = getattr(om, analysis_options["driver"]["name"])
                 prob.driver = Driver()
                 if "options" in analysis_options["driver"]:
-                    for option, value in analysis_options["driver"]["options"].items():
+                    for option, value_driver_option in analysis_options["driver"]["options"].items():
                         if option == "opt_settings":
-                            for opt_setting in value:
-                                prob.driver.opt_settings[opt_setting] = value[opt_setting]
+                            for key_opt_setting, value_opt_setting in value_driver_option.items():
+                                prob.driver.opt_settings[key_opt_setting] = value_opt_setting
                         else:
-                            prob.driver.options[option] = value
+                            prob.driver.options[option] = value_driver_option
 
                     # set design variables
             if "design_variables" in analysis_options:

--- a/ard/api/interface.py
+++ b/ard/api/interface.py
@@ -198,10 +198,17 @@ def set_up_system_recursive(
                 Driver = getattr(om, analysis_options["driver"]["name"])
                 prob.driver = Driver()
                 if "options" in analysis_options["driver"]:
-                    for option, value_driver_option in analysis_options["driver"]["options"].items():
+                    for option, value_driver_option in analysis_options["driver"][
+                        "options"
+                    ].items():
                         if option == "opt_settings":
-                            for key_opt_setting, value_opt_setting in value_driver_option.items():
-                                prob.driver.opt_settings[key_opt_setting] = value_opt_setting
+                            for (
+                                key_opt_setting,
+                                value_opt_setting,
+                            ) in value_driver_option.items():
+                                prob.driver.opt_settings[key_opt_setting] = (
+                                    value_opt_setting
+                                )
                         else:
                             prob.driver.options[option] = value_driver_option
 

--- a/ard/api/interface.py
+++ b/ard/api/interface.py
@@ -199,7 +199,11 @@ def set_up_system_recursive(
                 prob.driver = Driver()
                 if "options" in analysis_options["driver"]:
                     for option, value in analysis_options["driver"]["options"].items():
-                        prob.driver.options[option] = value
+                        if option == "opt_settings":
+                            for opt_setting in value:
+                                prob.driver.opt_settings[opt_setting] = value[opt_setting]
+                        else:
+                            prob.driver.options[option] = value
 
                     # set design variables
             if "design_variables" in analysis_options:


### PR DESCRIPTION
Discovered changes to COBYLA implementation across `scipy` 1.15 and 1.16 that necessitate `opt_settings` management, this allows that from Ard.

Closes #122, identical to it plus Black reformatting to preserve @jaredthomas68's weekend.