### PR TITLE
Hotfix/floris zeroed prob

### DIFF
--- a/ard/farm_aero/floris.py
+++ b/ard/farm_aero/floris.py
@@ -244,12 +244,21 @@ class FLORISFarmComponent:
             (len(self.fmodel.wind_data.wd_flat), self.fmodel.core.farm.n_turbines),
             0.0,
         )
+        V_turbines = np.full(
+            (len(self.fmodel.wind_data.wd_flat), self.fmodel.core.farm.n_turbines),
+            0.0,
+        )
+        A_floris = np.full(
+            (len(self.fmodel.wind_data.wd_flat), self.fmodel.core.farm.n_turbines),
+            0.0,
+        )
+
         CT_turbines[self.fmodel.wind_data.non_zero_freq_mask, :] = (
             self.fmodel.get_turbine_thrust_coefficients()
         )
-        V_turbines = self.fmodel.turbine_average_velocities
+        V_turbines[self.fmodel.wind_data.non_zero_freq_mask, :] = self.fmodel.turbine_average_velocities
         rho_floris = self.fmodel.core.flow_field.air_density
-        A_floris = np.pi * self.fmodel.core.farm.rotor_diameters**2 / 4
+        A_floris[self.fmodel.wind_data.non_zero_freq_mask, :] = np.pi * self.fmodel.core.farm.rotor_diameters**2 / 4
 
         thrust_turbines = CT_turbines * (0.5 * rho_floris * A_floris * V_turbines**2)
         return thrust_turbines.T

--- a/ard/farm_aero/floris.py
+++ b/ard/farm_aero/floris.py
@@ -247,13 +247,23 @@ class FLORISFarmComponent:
 
         # unpacking procedure
         # from FLORIS's floris_model.py:564 at a6fc5d35aa32614edc450dc399c42af60a816887
-        thrust_turbines = np.full(
-            (len(self.fmodel.wind_data.wind_directions), self.fmodel.core.farm.n_turbines),
-            0.0,
-        )
-        thrust_turbines[self.fmodel.wind_data.non_zero_freq_mask, :] = CT_turbines * (0.5 * rho_floris * A_floris * V_turbines**2)
-
-        return thrust_turbines.T
+        thrust_turbines = CT_turbines * (0.5 * rho_floris * A_floris * V_turbines**2)
+        if isinstance(self.fmodel.wind_data, floris.WindRose) or isinstance(
+            self.fmodel.wind_data, floris.WindRoseWRG
+        ):
+            thrust_turbines_densified = np.full(
+                (
+                    np.prod(self.fmodel.wind_data.freq_table.shape),
+                    self.fmodel.core.farm.n_turbines,
+                ),
+                0.0,
+            )
+            thrust_turbines_densified[self.fmodel.wind_data.non_zero_freq_mask, :] = (
+                thrust_turbines
+            )
+            return thrust_turbines_densified.T
+        else:
+            return thrust_turbines.T
 
     def dump_floris_yamlfile(self, dir_output=None):
         """

--- a/ard/farm_aero/floris.py
+++ b/ard/farm_aero/floris.py
@@ -256,9 +256,13 @@ class FLORISFarmComponent:
         CT_turbines[self.fmodel.wind_data.non_zero_freq_mask, :] = (
             self.fmodel.get_turbine_thrust_coefficients()
         )
-        V_turbines[self.fmodel.wind_data.non_zero_freq_mask, :] = self.fmodel.turbine_average_velocities
+        V_turbines[self.fmodel.wind_data.non_zero_freq_mask, :] = (
+            self.fmodel.turbine_average_velocities
+        )
         rho_floris = self.fmodel.core.flow_field.air_density
-        A_floris[self.fmodel.wind_data.non_zero_freq_mask, :] = np.pi * self.fmodel.core.farm.rotor_diameters**2 / 4
+        A_floris[self.fmodel.wind_data.non_zero_freq_mask, :] = (
+            np.pi * self.fmodel.core.farm.rotor_diameters**2 / 4
+        )
 
         thrust_turbines = CT_turbines * (0.5 * rho_floris * A_floris * V_turbines**2)
         return thrust_turbines.T

--- a/ard/farm_aero/floris.py
+++ b/ard/farm_aero/floris.py
@@ -240,6 +240,7 @@ class FLORISFarmComponent:
         # use pure FLORIS to get these values for consistency
 
         # prepare to unpack thrust data that is not pre-computed in FLORIS
+        # derived from FLORIS's floris_model.py:564 at a6fc5d35aa32614edc450dc399c42af60a816887
         CT_turbines = np.full(
             (len(self.fmodel.wind_data.wd_flat), self.fmodel.core.farm.n_turbines),
             0.0,

--- a/ard/farm_aero/floris.py
+++ b/ard/farm_aero/floris.py
@@ -240,32 +240,19 @@ class FLORISFarmComponent:
         # use pure FLORIS to get these values for consistency
 
         # prepare to unpack thrust data that is not pre-computed in FLORIS
-        # derived from FLORIS's floris_model.py:564 at a6fc5d35aa32614edc450dc399c42af60a816887
-        CT_turbines = np.full(
-            (len(self.fmodel.wind_data.wd_flat), self.fmodel.core.farm.n_turbines),
-            0.0,
-        )
-        V_turbines = np.full(
-            (len(self.fmodel.wind_data.wd_flat), self.fmodel.core.farm.n_turbines),
-            0.0,
-        )
-        A_floris = np.full(
-            (len(self.fmodel.wind_data.wd_flat), self.fmodel.core.farm.n_turbines),
-            0.0,
-        )
-
-        CT_turbines[self.fmodel.wind_data.non_zero_freq_mask, :] = (
-            self.fmodel.get_turbine_thrust_coefficients()
-        )
-        V_turbines[self.fmodel.wind_data.non_zero_freq_mask, :] = (
-            self.fmodel.turbine_average_velocities
-        )
+        CT_turbines = self.fmodel.get_turbine_thrust_coefficients()
+        V_turbines = self.fmodel.turbine_average_velocities
         rho_floris = self.fmodel.core.flow_field.air_density
-        A_floris[self.fmodel.wind_data.non_zero_freq_mask, :] = (
-            np.pi * self.fmodel.core.farm.rotor_diameters**2 / 4
-        )
+        A_floris = np.pi * self.fmodel.core.farm.rotor_diameters**2 / 4
 
-        thrust_turbines = CT_turbines * (0.5 * rho_floris * A_floris * V_turbines**2)
+        # unpacking procedure
+        # from FLORIS's floris_model.py:564 at a6fc5d35aa32614edc450dc399c42af60a816887
+        thrust_turbines = np.full(
+            (len(self.fmodel.wind_data.wind_directions), self.fmodel.core.farm.n_turbines),
+            0.0,
+        )
+        thrust_turbines[self.fmodel.wind_data.non_zero_freq_mask, :] = CT_turbines * (0.5 * rho_floris * A_floris * V_turbines**2)
+
         return thrust_turbines.T
 
     def dump_floris_yamlfile(self, dir_output=None):

--- a/ard/farm_aero/templates.py
+++ b/ard/farm_aero/templates.py
@@ -423,9 +423,10 @@ class FarmAEPTemplate(FarmAeroTemplate):
         if data_path is None:
             data_path = ""
 
-        self.directions_wind, self.speeds_wind, self.TIs_wind, self.pmf_wind, _, _ = (
-            self.wind_query.unpack()
-        )
+        self.directions_wind = self.wind_query.wind_directions
+        self.speeds_wind = self.wind_query.wind_speeds
+        self.TIs_wind = self.wind_query.ti_table_flat
+        self.pmf_wind = self.wind_query.freq_table_flat
         self.N_wind_conditions = len(self.pmf_wind)
 
         # add the outputs we want for an AEP analysis:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
   "openmdao",
   "shapely",
   "jax",
-  "optiwindnet>=0.0.4",
+  "optiwindnet==0.0.4",
   "statsmodels",
   "highspy",
   "pyyaml",


### PR DESCRIPTION
Discovered a problem where FLORIS's `model` treats the intended-public `get_turbine_powers` and intended-private `get_turbine_thrust_coefficients` methods have different behavior for wind roses with exactly-zero probabilities in direction-speed bins. Here, we export the behavior from [`get_turbine_powers`](https://github.com/NREL/floris/blob/a6fc5d35aa32614edc450dc399c42af60a816887/floris/floris_model.py#L564), allowing zero-probability thrusts to be defaulted to zero.