### PR TITLE
WindIO changed shear specification and python 11 compatibility

### DIFF
--- a/ard/__init__.py
+++ b/ard/__init__.py
@@ -1,13 +1,4 @@
 from pathlib import Path
 
-# from . import collection
-# from . import layout
-# from . import offshore
-# from . import wind_query
-# from . import utils
-# from . import viz
-
-# from .viz import house_style
-
 BASE_DIR = Path(__file__).parent.absolute()
 ASSET_DIR = BASE_DIR / "api" / "default_systems"

--- a/ard/__init__.py
+++ b/ard/__init__.py
@@ -1,13 +1,13 @@
 from pathlib import Path
 
-from . import collection
-from . import layout
-from . import offshore
-from . import wind_query
-from . import utils
-from . import viz
+# from . import collection
+# from . import layout
+# from . import offshore
+# from . import wind_query
+# from . import utils
+# from . import viz
 
-from .viz import house_style
+# from .viz import house_style
 
 BASE_DIR = Path(__file__).parent.absolute()
 ASSET_DIR = BASE_DIR / "api" / "default_systems"

--- a/ard/api/interface.py
+++ b/ard/api/interface.py
@@ -5,11 +5,6 @@ from wisdem.optimization_drivers.nsga2_driver import NSGA2Driver
 from openmdao.utils.file_utils import clean_outputs
 from ard.utils.io import load_yaml, replace_key_value
 from ard.utils.logging import prepend_tabs_to_stdio
-from ard.cost.wisdem_wrap import (
-    LandBOSSE_setup_latents,
-    ORBIT_setup_latents,
-    FinanceSE_setup_latents,
-)
 import windIO
 from ard import ASSET_DIR
 from typing import Union
@@ -163,12 +158,11 @@ def set_up_system_recursive(
         prob = None
 
     # Add subsystems directly from the input dictionary
+    indent = "\t" * _depth
     if hasattr(parent_group, "name") and (parent_group.name != ""):
-        print(
-            f"{''.join(['\t' for _ in range(_depth)])}Adding {system_name} to {parent_group.name}."
-        )
+        print(f"{indent}Adding {system_name} to {parent_group.name}.")
     else:
-        print(f"{''.join(['\t' for _ in range(_depth)])}Adding {system_name}.")
+        print(f"{indent}Adding {system_name}.")
     if "systems" in input_dict:  # Recursively add nested subsystems]
         if _depth > 0:
             group = parent_group.add_subsystem(

--- a/ard/farm_aero/floris.py
+++ b/ard/farm_aero/floris.py
@@ -197,13 +197,14 @@ class FLORISFarmComponent:
 
         # set up FLORIS
         self.fmodel = floris.FlorisModel("defaults")
-        data_path = self.options["data_path"]
         self.fmodel.set(
             turbine_type=[
                 create_FLORIS_turbine_from_windIO(self.windIO, self.modeling_options),
             ],
             wind_shear=self.windIO["site"]["energy_resource"]["wind_resource"].get(
-                "shear"
+                "shear", {},
+            ).get(
+                "alpha"
             ),
             reference_wind_height=getattr(
                 self.wind_query,

--- a/ard/farm_aero/floris.py
+++ b/ard/farm_aero/floris.py
@@ -201,11 +201,12 @@ class FLORISFarmComponent:
             turbine_type=[
                 create_FLORIS_turbine_from_windIO(self.windIO, self.modeling_options),
             ],
-            wind_shear=self.windIO["site"]["energy_resource"]["wind_resource"].get(
-                "shear", {},
-            ).get(
-                "alpha"
-            ),
+            wind_shear=self.windIO["site"]["energy_resource"]["wind_resource"]
+            .get(
+                "shear",
+                {},
+            )
+            .get("alpha"),
             reference_wind_height=getattr(
                 self.wind_query,
                 "reference_height",

--- a/ard/farm_aero/templates.py
+++ b/ard/farm_aero/templates.py
@@ -51,6 +51,21 @@ def create_windresource_from_windIO(
     # get the wind resource specification out of the dictionary
     wind_resource = windIOdict["site"]["energy_resource"]["wind_resource"]
 
+    reference_height = wind_resource.get("reference_height")
+    h_ref = wind_resource.get("shear", {}).get("h_ref")
+    if (
+        reference_height is not None
+        and h_ref is not None
+        and not np.isclose(reference_height, h_ref)
+    ):
+        raise ValueError(
+            "Both 'reference_height' and 'h_ref' were provided in wind_resource "
+            f"with different values ({reference_height} vs {h_ref})."
+        )
+    wind_resource_reference_height = (
+        reference_height if reference_height is not None else h_ref
+    )
+
     # figure out the case in play
     fields_wind_resource = wind_resource.keys()
     case_probability_based = all(
@@ -122,11 +137,7 @@ def create_windresource_from_windIO(
             ti_table=turbulence_intensities,
         )
         # stash some metadata for the wind resource
-        wind_resource_representation.reference_height = (
-            wind_resource["reference_height"]
-            if "reference_height" in wind_resource
-            else None
-        )
+        wind_resource_representation.reference_height = wind_resource_reference_height
 
         return wind_resource_representation
 
@@ -165,11 +176,7 @@ def create_windresource_from_windIO(
             turbulence_intensities=turbulence_intensities,
         )
         # stash some metadata for the wind resource
-        wind_resource_representation.reference_height = (
-            wind_resource["reference_height"]
-            if "reference_height" in wind_resource
-            else None
-        )
+        wind_resource_representation.reference_height = wind_resource_reference_height
         wind_resource_representation.time = (
             wind_resource["time"] if "time" in wind_resource else None
         )

--- a/ard/utils/__init__.py
+++ b/ard/utils/__init__.py
@@ -1,1 +1,0 @@
-from . import test_utils

--- a/examples/01_onshore/optimization_demo.ipynb
+++ b/examples/01_onshore/optimization_demo.ipynb
@@ -51,7 +51,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "29850609",
    "metadata": {},
    "outputs": [
@@ -60,19 +60,27 @@
      "output_type": "stream",
      "text": [
       "Running OpenMDAO util to clean the output directories...\n",
-      "\tNo OpenMDAO output directories found.\n",
+      "\tFound 1 OpenMDAO output directories:\n",
+      "\tRemoved case_files/COBYLA_optimization_out\n",
+      "\tRemoved 1 OpenMDAO output directories.\n",
       "... done.\n",
       "\n",
       "Created top-level OpenMDAO problem: top_level.\n",
       "Adding top_level.\n",
-      "    Adding layout2aep.\n",
-      "> \u001b[32m/Users/jthomas2/Documents/programs/Ard/ard/api/interface.py\u001b[39m(\u001b[92m168\u001b[39m)\u001b[36mset_up_system_recursive\u001b[39m\u001b[34m()\u001b[39m\n",
-      "\u001b[32m    166\u001b[39m     \u001b[38;5;28;01mif\u001b[39;00m hasattr(parent_group, \u001b[33m\"name\"\u001b[39m) \u001b[38;5;28;01mand\u001b[39;00m (parent_group.name != \u001b[33m\"\"\u001b[39m):\n",
-      "\u001b[32m    167\u001b[39m         \u001b[38;5;28;01mimport\u001b[39;00m pdb; pdb.set_trace()\n",
-      "\u001b[32m--> 168\u001b[39m         print(\n",
-      "\u001b[32m    169\u001b[39m             f\"{\u001b[33m''\u001b[39m.join([\u001b[33m'    '\u001b[39m \u001b[38;5;28;01mfor\u001b[39;00m _ \u001b[38;5;28;01min\u001b[39;00m range(_depth)])}Adding {system_name} to {parent_group.name}.\"\n",
-      "\u001b[32m    170\u001b[39m         )\n",
-      "\n"
+      "\tAdding layout2aep.\n",
+      "\t\tAdding layout to layout2aep.\n",
+      "\t\tAdding aepFLORIS to layout2aep.\n",
+      "\tActivating approximate totals on layout2aep\n",
+      "\tAdding boundary.\n",
+      "\tAdding landuse.\n",
+      "\tAdding collection.\n",
+      "\tAdding spacing_constraint.\n",
+      "\tAdding tcc.\n",
+      "\tAdding landbosse.\n",
+      "\tAdding opex.\n",
+      "\tAdding financese.\n",
+      "System top_level built.\n",
+      "System top_level set up.\n"
      ]
     }
    ],
@@ -98,7 +106,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "id": "aa48878e",
    "metadata": {},
    "outputs": [],
@@ -119,7 +127,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "id": "b74f9d45",
    "metadata": {},
    "outputs": [
@@ -187,7 +195,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "id": "b0009663",
    "metadata": {},
    "outputs": [
@@ -901,7 +909,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "id": "f93a46df",
    "metadata": {},
    "outputs": [
@@ -945,7 +953,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "ard-env",
+   "display_name": "ard-dev-env",
    "language": "python",
    "name": "python3"
   },
@@ -959,7 +967,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.12"
+   "version": "3.12.11"
   }
  },
  "nbformat": 4,

--- a/examples/01_onshore/optimization_demo.ipynb
+++ b/examples/01_onshore/optimization_demo.ipynb
@@ -51,7 +51,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "29850609",
    "metadata": {},
    "outputs": [
@@ -60,27 +60,19 @@
      "output_type": "stream",
      "text": [
       "Running OpenMDAO util to clean the output directories...\n",
-      "\tFound 1 OpenMDAO output directories:\n",
-      "\tRemoved case_files/COBYLA_optimization_out\n",
-      "\tRemoved 1 OpenMDAO output directories.\n",
+      "\tNo OpenMDAO output directories found.\n",
       "... done.\n",
       "\n",
       "Created top-level OpenMDAO problem: top_level.\n",
       "Adding top_level.\n",
-      "\tAdding layout2aep.\n",
-      "\t\tAdding layout to layout2aep.\n",
-      "\t\tAdding aepFLORIS to layout2aep.\n",
-      "\tActivating approximate totals on layout2aep\n",
-      "\tAdding boundary.\n",
-      "\tAdding landuse.\n",
-      "\tAdding collection.\n",
-      "\tAdding spacing_constraint.\n",
-      "\tAdding tcc.\n",
-      "\tAdding landbosse.\n",
-      "\tAdding opex.\n",
-      "\tAdding financese.\n",
-      "System top_level built.\n",
-      "System top_level set up.\n"
+      "    Adding layout2aep.\n",
+      "> \u001b[32m/Users/jthomas2/Documents/programs/Ard/ard/api/interface.py\u001b[39m(\u001b[92m168\u001b[39m)\u001b[36mset_up_system_recursive\u001b[39m\u001b[34m()\u001b[39m\n",
+      "\u001b[32m    166\u001b[39m     \u001b[38;5;28;01mif\u001b[39;00m hasattr(parent_group, \u001b[33m\"name\"\u001b[39m) \u001b[38;5;28;01mand\u001b[39;00m (parent_group.name != \u001b[33m\"\"\u001b[39m):\n",
+      "\u001b[32m    167\u001b[39m         \u001b[38;5;28;01mimport\u001b[39;00m pdb; pdb.set_trace()\n",
+      "\u001b[32m--> 168\u001b[39m         print(\n",
+      "\u001b[32m    169\u001b[39m             f\"{\u001b[33m''\u001b[39m.join([\u001b[33m'    '\u001b[39m \u001b[38;5;28;01mfor\u001b[39;00m _ \u001b[38;5;28;01min\u001b[39;00m range(_depth)])}Adding {system_name} to {parent_group.name}.\"\n",
+      "\u001b[32m    170\u001b[39m         )\n",
+      "\n"
      ]
     }
    ],
@@ -106,7 +98,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "aa48878e",
    "metadata": {},
    "outputs": [],
@@ -127,7 +119,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "b74f9d45",
    "metadata": {},
    "outputs": [
@@ -195,7 +187,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "b0009663",
    "metadata": {},
    "outputs": [
@@ -909,7 +901,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "id": "f93a46df",
    "metadata": {},
    "outputs": [
@@ -953,7 +945,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "ard-dev-env",
+   "display_name": "ard-env",
    "language": "python",
    "name": "python3"
   },
@@ -967,7 +959,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.11"
+   "version": "3.12.12"
   }
  },
  "nbformat": 4,

--- a/test/ard/unit/cost/test_orbit_wrap.py
+++ b/test/ard/unit/cost/test_orbit_wrap.py
@@ -29,7 +29,9 @@ class TestORBITNoApproxBranch:
             "site": {
                 "energy_resource": {
                     "wind_resource": {
-                        "shear": 0.2,
+                        "shear": {
+                            "alpha": 0.2,
+                        },
                     },
                 },
             },
@@ -211,7 +213,9 @@ class TestORBITNoApproxBranch:
             "site": {
                 "energy_resource": {
                     "wind_resource": {
-                        "shear": 0.2,
+                        "shear": {
+                            "alpha": 0.2,
+                        },
                     },
                 },
             },
@@ -408,7 +412,9 @@ class TestORBITApproxBranch:
             "site": {
                 "energy_resource": {
                     "wind_resource": {
-                        "shear": 0.2,
+                        "shear": {
+                            "alpha": 0.2,
+                        },
                     },
                 },
             },

--- a/test/ard/unit/cost/test_wisdem_wrap.py
+++ b/test/ard/unit/cost/test_wisdem_wrap.py
@@ -26,7 +26,9 @@ class TestLandBOSSE:
                 "site": {
                     "energy_resource": {
                         "wind_resource": {
-                            "shear": 0.2,
+                            "shear": {
+                                "alpha": 0.2,
+                            },
                         },
                     },
                 },

--- a/test/ard/unit/farm_aero/test_floris.py
+++ b/test/ard/unit/farm_aero/test_floris.py
@@ -12,6 +12,7 @@ import ard.utils.test_utils
 import ard.wind_query as wq
 import ard.farm_aero.floris as farmaero_floris
 
+
 class TestFLORISFarmComponent:
 
     def setup_method(self):

--- a/test/ard/unit/farm_aero/test_floris.py
+++ b/test/ard/unit/farm_aero/test_floris.py
@@ -11,59 +11,6 @@ import ard.utils.io
 import ard.utils.test_utils
 import ard.wind_query as wq
 import ard.farm_aero.floris as farmaero_floris
-import ard.farm_aero.templates as farmaero_templates
-
-
-def _build_timeseries_windio(reference_height=None, h_ref=None):
-    wind_resource = {
-        "wind_direction": [270.0, 280.0],
-        "wind_speed": [8.0, 9.0],
-        "turbulence_intensity": [0.06, 0.06],
-        "time": [0, 1],
-    }
-    if reference_height is not None:
-        wind_resource["reference_height"] = reference_height
-    if h_ref is not None:
-        wind_resource["shear"] = {
-            "h_ref": h_ref
-        }
-
-    return {
-        "site": {
-            "energy_resource": {
-                "wind_resource": wind_resource,
-            },
-        },
-    }
-
-
-class TestWindResourceReferenceHeightAliases:
-
-    def test_reference_height_or_h_ref_single_key(self):
-        windio_ref = _build_timeseries_windio(reference_height=110.0)
-        resource_ref = farmaero_templates.create_windresource_from_windIO(
-            windio_ref, "timeseries"
-        )
-        assert resource_ref.reference_height == 110.0
-
-        windio_href = _build_timeseries_windio(h_ref=95.0)
-        resource_href = farmaero_templates.create_windresource_from_windIO(
-            windio_href, "timeseries"
-        )
-        assert resource_href.reference_height == 95.0
-
-    def test_reference_height_and_h_ref_same_value(self):
-        windio = _build_timeseries_windio(reference_height=100.0, h_ref=100.0)
-        resource = farmaero_templates.create_windresource_from_windIO(
-            windio, "timeseries"
-        )
-        assert resource.reference_height == 100.0
-
-    def test_reference_height_and_h_ref_different_values_raise(self):
-        windio = _build_timeseries_windio(reference_height=100.0, h_ref=101.0)
-        with pytest.raises(ValueError, match="reference_height.*h_ref"):
-            farmaero_templates.create_windresource_from_windIO(windio, "timeseries")
-
 
 class TestFLORISFarmComponent:
 

--- a/test/ard/unit/farm_aero/test_floris.py
+++ b/test/ard/unit/farm_aero/test_floris.py
@@ -11,6 +11,58 @@ import ard.utils.io
 import ard.utils.test_utils
 import ard.wind_query as wq
 import ard.farm_aero.floris as farmaero_floris
+import ard.farm_aero.templates as farmaero_templates
+
+
+def _build_timeseries_windio(reference_height=None, h_ref=None):
+    wind_resource = {
+        "wind_direction": [270.0, 280.0],
+        "wind_speed": [8.0, 9.0],
+        "turbulence_intensity": [0.06, 0.06],
+        "time": [0, 1],
+    }
+    if reference_height is not None:
+        wind_resource["reference_height"] = reference_height
+    if h_ref is not None:
+        wind_resource["shear"] = {
+            "h_ref": h_ref
+        }
+
+    return {
+        "site": {
+            "energy_resource": {
+                "wind_resource": wind_resource,
+            },
+        },
+    }
+
+
+class TestWindResourceReferenceHeightAliases:
+
+    def test_reference_height_or_h_ref_single_key(self):
+        windio_ref = _build_timeseries_windio(reference_height=110.0)
+        resource_ref = farmaero_templates.create_windresource_from_windIO(
+            windio_ref, "timeseries"
+        )
+        assert resource_ref.reference_height == 110.0
+
+        windio_href = _build_timeseries_windio(h_ref=95.0)
+        resource_href = farmaero_templates.create_windresource_from_windIO(
+            windio_href, "timeseries"
+        )
+        assert resource_href.reference_height == 95.0
+
+    def test_reference_height_and_h_ref_same_value(self):
+        windio = _build_timeseries_windio(reference_height=100.0, h_ref=100.0)
+        resource = farmaero_templates.create_windresource_from_windIO(
+            windio, "timeseries"
+        )
+        assert resource.reference_height == 100.0
+
+    def test_reference_height_and_h_ref_different_values_raise(self):
+        windio = _build_timeseries_windio(reference_height=100.0, h_ref=101.0)
+        with pytest.raises(ValueError, match="reference_height.*h_ref"):
+            farmaero_templates.create_windresource_from_windIO(windio, "timeseries")
 
 
 class TestFLORISFarmComponent:
@@ -59,7 +111,9 @@ class TestFLORISBatchPower:
                             "wind_speed": wind_query.get_speeds().tolist(),
                             "turbulence_intensity": wind_query.get_TIs().tolist(),
                             "time": np.zeros_like(wind_query.get_speeds().tolist()),
-                            "shear": 0.585,
+                            "shear": {
+                                "alpha": 0.585,
+                            },
                         },
                         "reference_height": 90.0,
                     },
@@ -204,7 +258,9 @@ class TestFLORISAEP:
                                     "wind_speed",
                                 ],
                             },
-                            "shear": 0.585,
+                            "shear": {
+                                "alpha": 0.585,
+                            },
                             "reference_height": 110.0,
                         },
                     },

--- a/test/ard/unit/farm_aero/test_templates.py
+++ b/test/ard/unit/farm_aero/test_templates.py
@@ -7,6 +7,58 @@ import pytest
 
 import ard.wind_query as wq
 import ard.farm_aero.templates as templates
+import ard.farm_aero.templates as farmaero_templates
+
+
+def _build_timeseries_windio(reference_height=None, h_ref=None):
+    wind_resource = {
+        "wind_direction": [270.0, 280.0],
+        "wind_speed": [8.0, 9.0],
+        "turbulence_intensity": [0.06, 0.06],
+        "time": [0, 1],
+    }
+    if reference_height is not None:
+        wind_resource["reference_height"] = reference_height
+    if h_ref is not None:
+        wind_resource["shear"] = {
+            "h_ref": h_ref
+        }
+
+    return {
+        "site": {
+            "energy_resource": {
+                "wind_resource": wind_resource,
+            },
+        },
+    }
+
+
+class TestWindResourceReferenceHeightAliases:
+
+    def test_reference_height_or_h_ref_single_key(self):
+        windio_ref = _build_timeseries_windio(reference_height=110.0)
+        resource_ref = farmaero_templates.create_windresource_from_windIO(
+            windio_ref, "timeseries"
+        )
+        assert resource_ref.reference_height == 110.0
+
+        windio_href = _build_timeseries_windio(h_ref=95.0)
+        resource_href = farmaero_templates.create_windresource_from_windIO(
+            windio_href, "timeseries"
+        )
+        assert resource_href.reference_height == 95.0
+
+    def test_reference_height_and_h_ref_same_value(self):
+        windio = _build_timeseries_windio(reference_height=100.0, h_ref=100.0)
+        resource = farmaero_templates.create_windresource_from_windIO(
+            windio, "timeseries"
+        )
+        assert resource.reference_height == 100.0
+
+    def test_reference_height_and_h_ref_different_values_raise(self):
+        windio = _build_timeseries_windio(reference_height=100.0, h_ref=101.0)
+        with pytest.raises(ValueError, match="reference_height.*h_ref"):
+            farmaero_templates.create_windresource_from_windIO(windio, "timeseries")
 
 
 class TestFarmAeroTemplate:

--- a/test/ard/unit/farm_aero/test_templates.py
+++ b/test/ard/unit/farm_aero/test_templates.py
@@ -20,9 +20,7 @@ def _build_timeseries_windio(reference_height=None, h_ref=None):
     if reference_height is not None:
         wind_resource["reference_height"] = reference_height
     if h_ref is not None:
-        wind_resource["shear"] = {
-            "h_ref": h_ref
-        }
+        wind_resource["shear"] = {"h_ref": h_ref}
 
     return {
         "site": {

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 
 
@@ -6,11 +7,11 @@ def pytest_sessionfinish(session, exitstatus):
 
     # for each tempdir
     for pytest_out_dir in Path().glob("pytest*_out"):
-        for root, dirs, files in pytest_out_dir.walk(
-            top_down=False
+        for root, dirs, files in os.walk(
+            str(pytest_out_dir), topdown=False
         ):  # walk the directory
             for name in files:
-                (root / name).unlink()  # remove subdirectory files, and
+                Path(root, name).unlink()  # remove subdirectory files, and
             for name in dirs:
-                (root / name).rmdir()  # remove subdirectories
+                Path(root, name).rmdir()  # remove subdirectories
         pytest_out_dir.rmdir()  # then remove that tempdir


### PR DESCRIPTION
This PR makes a few necessary adjustments to work with H2Integrate

1. In H2Integrate, the wind resource is passed in as a windIO file to Ard, and windIO recently changed the shear specification. This PR updates the shear specification, which now includes both `alpha` and `h_ref` in a dict. New tests were also added for the new functionality. 
3. There was some string handling in Ard that was not compatible with python 11, this PR updates the string handling to work with python >=3.11
4. Imports were not working when called inside of H2I, so some modules inside Ard were unreachable. This PR corrects the sub-module imports (mostly by removing them) so that Ard imports work from any directory.