### PR TITLE
Migrate away from optiwindnet's EW_presolver deprecated heuristic

### DIFF
--- a/ard/collection/optiwindnet_wrap.py
+++ b/ard/collection/optiwindnet_wrap.py
@@ -5,7 +5,7 @@ import numpy as np
 
 from optiwindnet.mesh import make_planar_embedding
 from optiwindnet.interarraylib import L_from_site
-from optiwindnet.heuristics import EW_presolver
+from optiwindnet.heuristics import constructor
 from optiwindnet.MILP import OWNWarmupFailed, solver_factory, ModelOptions
 
 from . import templates
@@ -153,6 +153,18 @@ class OptiwindnetCollection(templates.CollectionTemplate):
     def setup(self):
         """Setup of OM component."""
         super().setup()
+        self.constructor_args = {}
+        model_options = self.modeling_options["collection"]["model_options"]
+        if model_options.get("feeder_limit") == "unlimited":
+            self.constructor_args["straight_feeder_route"] = (
+                model_options.get("feeder_route") == "straight"
+            )
+            if model_options.get("topology") == "branched":
+                self.constructor_args["method"] = "rootlust"
+            elif model_options.get("topology") == "radial":
+                self.constructor_args["method"] = "radial_EW"
+            else:
+                self.constructor_args.clear()
 
     def setup_partials(self):
         """Setup of OM component gradients."""
@@ -192,12 +204,12 @@ class OptiwindnetCollection(templates.CollectionTemplate):
         # start from previous solution if available, else from heuristic if it fits
         if self.S_previous is not None:
             S_warm = self.S_previous
-        elif (
-            model_options.get("topology") == "branched"
-            and model_options.get("feeder_limit") == "unlimited"
-            and model_options.get("feeder_route") == "segmented"
-        ):
-            S_warm = EW_presolver(A, capacity=max_turbines_per_string)
+        elif self.constructor_args:
+            S_warm = constructor(
+                A,
+                capacity=max_turbines_per_string,
+                **self.constructor_args,
+            )
         else:
             S_warm = None
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
   "openmdao",
   "shapely",
   "jax",
-  "optiwindnet>=0.0.6",
+  "optiwindnet>=0.2.2",
   "statsmodels",
   "highspy",
   "pyyaml",


### PR DESCRIPTION
The collection system module wraps optiwindnet's EW_presolver to warm-start the electrical network optimization. This heuristic has been deprecated in optiwindnet v0.2.2 (which shows a warning when EW_presolver is called) and will be removed in v0.3.

This commit updates optiwindnet_wrap.py to use the new implementation, which uses an improved algorithm by default: optiwindnet.heuristics.constructor(). It has the additional advantage of being able to produce solutions with radial topology (non-branching turbine strings).

This commit also updates the dependencies (optiwindnet >= 0.2.2) to avoid version-checking in the code.

The tests show multiple failures, but those also happen with the parent commit. The specific tests:
- test/ard/system/collection/test_optiwindnet.py - PASSED
- test/ard/unit/collection/test_optiwindnet.py - PASSED